### PR TITLE
Add Economy Shipping Option to Types

### DIFF
--- a/.changeset/twelve-timers-juggle.md
+++ b/.changeset/twelve-timers-juggle.md
@@ -1,0 +1,5 @@
+---
+"printify-nodejs": patch
+---
+
+Add Economy Shipping Option to Types

--- a/src/types/orders.ts
+++ b/src/types/orders.ts
@@ -162,4 +162,5 @@ export type CalculateOrderShippingCostResponse = {
     express: number;
     priority: number;
     printify_express: number;
+    economy: number;
 };

--- a/src/types/products.ts
+++ b/src/types/products.ts
@@ -54,7 +54,10 @@ type Product = {
     updated_at: string;
     visible: boolean;
     is_locked: boolean;
-    is_printify_express_eligible: boolean;
+    is_printify_express_eligible: boolean,
+    is_printify_express_enabled: boolean,
+    is_economy_shipping_eligible: boolean,
+    is_economy_shipping_enabled: boolean,
     blueprint_id: number;
     user_id: number;
     shop_id: number;


### PR DESCRIPTION
Add the keys for the recent API updates from Printify relating to the addition of economy shipping