### PR TITLE
Add property of name to BasicOption and ColorOption type

### DIFF
--- a/src/types/products.ts
+++ b/src/types/products.ts
@@ -6,6 +6,7 @@ export type ProductOptionBase = {
 
 export type ColorOption = ProductOptionBase & {
     type: "color";
+    name: string;
     values: {
         id: number;
         title: string;
@@ -15,6 +16,7 @@ export type ColorOption = ProductOptionBase & {
 
 export type BasicOption = ProductOptionBase & {
     type: string;
+    name: string;
     values: {
         id: number;
         title: string;


### PR DESCRIPTION
Add the property to the option as per the Printify Developer API guide:

 "options": [
         {
             "name": "Size",
             "type": "size",
             "values": [
                 {
                     "id": 2017,
                     "title": "2x2\""
                 },
                 {
                     "id": 2018,
                     "title": "3x3\""
                 },
                 {
                     "id": 2019,
                     "title": "4x4\""
                 },
                 {
                     "id": 2020,
                     "title": "6x6\""
                 }
             ]
         },
         {
             "name": "Type",
             "type": "surface",
             "values": [
                 {
                     "id": 2114,
                     "title": "White"
                 }
             ]
         }
     ],