### PR TITLE
Add quantity to ProductVariant Type

### DIFF
--- a/.changeset/proud-onions-hug.md
+++ b/.changeset/proud-onions-hug.md
@@ -1,0 +1,5 @@
+---
+"printify-nodejs": patch
+---
+
+Add quantity to ProductVariant Type with a disclaimer

--- a/src/types/products.ts
+++ b/src/types/products.ts
@@ -35,6 +35,9 @@ export interface ProductVariant {
     is_available?: boolean;
     is_printify_express_eligible?: boolean;
     options?: number[];
+    /**
+     * This is not documented on the Printify's official documentation but was found to part of the responses.
+     */
     quantity?: number;
 }
 

--- a/src/types/products.ts
+++ b/src/types/products.ts
@@ -35,6 +35,7 @@ export interface ProductVariant {
     is_available?: boolean;
     is_printify_express_eligible?: boolean;
     options?: number[];
+    quantity?: number;
 }
 
 type Product = {


### PR DESCRIPTION
This is an odd one.  The Printify API docs do not show a property of quantity, but I can confirm that it is returned when you get products or create products. I opted to leave it optional at this point, given the unknown use or future of it.